### PR TITLE
CodeSigningConfig resource naming fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -549,7 +549,7 @@ class ServerlessPlugin {
 
 // Making sure the resource's logical ID is alphanumeric.
 function normalizeResourceName(name) {
-  return name.replace(
+  return name.replace( // PascalCase as done by serverless fw
     /[^-_]*[-_]*/g,
     txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
   ).replaceAll('-', 'Dash').replaceAll('_', 'Underscore');

--- a/index.js
+++ b/index.js
@@ -549,10 +549,10 @@ class ServerlessPlugin {
 
 // Making sure the resource's logical ID is alphanumeric.
 function normalizeResourceName(name) {
-  return name.replace( // PascalCase as done by serverless fw
+  return name.replace(
     /[^-_]*[-_]*/g,
     txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
-  ).replaceAll('-', 'Dash').replaceAll('_', 'Underscore');
+  ).replace(/-/g, 'Dash').replace(/_/g, 'Underscore');
 }
 
 module.exports = ServerlessPlugin;

--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ class ServerlessPlugin {
     for (let lambda in signerProcesses) {
       const profileName = signerProcesses[lambda].signerConfiguration.profileName;
       const signingPolicy = signerProcesses[lambda].signerConfiguration.signingPolicy;
-      const resourceName = lambda+"CodeSigningConfig";
+      const resourceName = normalizeResourceName(lambda) + "CodeSigningConfig";
       // Copy deployment artifact to S3
 
       var profileArn = await signersMethods.getProfileParamByName(profileName, 'profileVersionArn', this.serverless)
@@ -545,6 +545,14 @@ class ServerlessPlugin {
 
   }
 
+}
+
+// Making sure the resource's logical ID is alphanumeric.
+function normalizeResourceName(name) {
+  return name.replace(
+    /[^-_]*[-_]*/g,
+    txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+  ).replaceAll('-', 'Dash').replaceAll('_', 'Underscore');
 }
 
 module.exports = ServerlessPlugin;


### PR DESCRIPTION
Serverless allows naming functions with dashes and underscores.
Since cloudformation logical IDs are alphanumeric, in related resource names, it replaces dashes and underscores and transforms the function name to Pascal case.

Added the same logic for the CodeSigningConfig resource naming.